### PR TITLE
Fixed closeFile method in parallel chains

### DIFF
--- a/baseConfig.ini
+++ b/baseConfig.ini
@@ -90,9 +90,6 @@ GRstop  = 0.01
 ;every number of steps check the GR-criteria
 checkGR = 500
 
-;1 if single cpu , otherwise is giving by the nproc-> mpi -np #
-chainno = 0
-
 
 [nested]
 ;type for dynesty -> {'single','multi', 'balls', 'cubes'}

--- a/simplemc/analyzers/MCMCAnalyzer.py
+++ b/simplemc/analyzers/MCMCAnalyzer.py
@@ -172,6 +172,7 @@ class MCMCAnalyzer:
                 recvmsg = comm.bcast(condition, root=0)
                 if recvmsg ==1:
                     print('\n---- Gelman-Rubin achived ---- ')
+                    self.closeFiles()
                     return True
 
 


### PR DESCRIPTION
In this Pull Request, only two files are affected: 

- `baseConfig.ini`: chainno parameter is  deprecated and the number of parallel chains must be indicated by the mpi -np command.
- `MCMCAnalyzer`. Only one line is added in order to avoid a file closing error where there are several parallel chains. 