### PR TITLE
fix mpi4py import and allow to run whitout it

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# Requirements of Python3 for SimpleMC 2.0, keras and tensorflow are optional.
+# Requirements of Python3 for SimpleMC 2.0.
 # pip3 install -r requirements.txt
 numpy
 scipy

--- a/requirements_full.txt
+++ b/requirements_full.txt
@@ -7,7 +7,6 @@ scipy
 sklearn
 deap
 mpi4py
-tensorflow
 corner
 getdist
 fgivenx

--- a/requirements_full.txt
+++ b/requirements_full.txt
@@ -10,4 +10,5 @@ mpi4py
 tensorflow
 corner
 getdist
+fgivenx
 tqdm


### PR DESCRIPTION
The `mpi4py` import was moved into the `MCMCAnalyzer class`. In addition, we add a few of exceptions to allow running `MCMCAnalyzer` without `mpi4py` installed using only 1 processor and generating 1 chain, also these changes allow to use the rest of `simplemc` without having `mpi4py`.