### PR TITLE
Gaussian priors

### DIFF
--- a/simplemc/DriverMC.py
+++ b/simplemc/DriverMC.py
@@ -5,7 +5,7 @@ from .cosmo.Derivedparam import AllDerived
 from .setup_logger import logger
 from .runbase import ParseDataset, ParseModel
 from .PostProcessing import PostProcessing
-from scipy.stats import truncnorm
+from scipy.special import ndtri
 import numpy as np
 import sys, os
 import time
@@ -726,11 +726,14 @@ class DriverMC:
         n = self.nsigma
         # if the prior is gaussian
         if self.priortype == 'g':
-            for c, bound in enumerate(self.bounds):
+            for c in range(len(theta)):
                 mu = self.means[c]
                 sigma = self.errors[c]
-                a, b = (bound[0] - mu) / sigma, (bound[1] - mu) / sigma  # truncation in std units
-                prior_val = truncnorm.ppf(theta[c], a, b, loc=mu, scale=sigma)
+                if sigma == 0:
+                    raise ValueError(f"Standard deviation (err) is zero for parameter {c}. "
+                                     "Cannot define a Gaussian prior with err = 0.")
+                bound = self.bounds[c]
+                prior_val = mu + sigma * ndtri(theta[c])
                 priors.append(prior_val)
         # if the prior is uniform        
         else:


### PR DESCRIPTION
In this PR, only a few lines in the `DriverMC.py` module were modified to correct the use of Gaussian priors when using nested sampling as the analyzer. The errors defined in `cosmo.paramDefs` can then be used as standard deviations of Gaussian distributions.

Without these changes, an error occurs when selecting a Gaussian prior from the `ini` file, for example:

```
analyzer = nested
priortype = g
```
<img width="1321" height="129" alt="image" src="https://github.com/user-attachments/assets/78649cd0-204d-492d-a444-ed77f0071c31" />

There is no risk of changing anything else by accepting this pull request.

Cheers.
